### PR TITLE
fix: mettre à jour l'URL de BASE_URL dans le sitemap pour inclure 'www'

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,22 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/(.*)",
+        has: [
+          {
+            type: "host",
+            value: "matheolang.fr",
+            protocol: "http",
+          }
+        ],
+        destination: "https://www.matheolang.fr/:path*",
+        permanent: true,
+      }
+    ]
+  }
 };
 
 export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,22 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  async redirects() {
-    return [
-      {
-        source: "/(.*)",
-        has: [
-          {
-            type: "host",
-            value: "matheolang.fr",
-            protocol: "http",
-          }
-        ],
-        destination: "https://www.matheolang.fr/:path*",
-        permanent: true,
-      }
-    ]
-  }
 };
 
 export default nextConfig;

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import { MetadataRoute } from "next";
 
-export const BASE_URL = 'https://matheolang.fr';
+export const BASE_URL = 'https://www.matheolang.fr';
 
 export const paths = [
     '/',


### PR DESCRIPTION
This pull request introduces changes to enforce the use of the "www" subdomain for the `matheolang.fr` domain by implementing a redirect and updating the base URL in the sitemap configuration.

### Redirect configuration:

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bL4-R19): Added a redirect rule to enforce HTTPS and prepend "www" to requests targeting `matheolang.fr` without the subdomain. This ensures all traffic is routed to `https://www.matheolang.fr`.

### Sitemap update:

* [`src/app/sitemap.ts`](diffhunk://#diff-d61cbfe152f276a1db8b4db1af2171f2d9a120bd26020f8818c602ca1477d4a1L3-R3): Updated the `BASE_URL` constant to use `https://www.matheolang.fr` instead of `https://matheolang.fr`, aligning the sitemap with the enforced redirect.